### PR TITLE
convert CI trigger to PR opening on staging

### DIFF
--- a/.github/workflows/production_cd.yml
+++ b/.github/workflows/production_cd.yml
@@ -13,16 +13,15 @@ jobs:
       contents: read
       packages: write
 
-    # only run if the commit came from the staging branch
-    # note, if this commit message changes in staging_ci.yml, it needs to be updated here, too
-    # borken because the commit messages aren't lining up
-    # if: github.event_name == 'push' && contains(github.event.head_commit.message, 'Merge staging into production after successful CI')
     env:
       VITE_DATABASE_ENDPOINT: ${{ secrets.VITE_DATABASE_ENDPOINT }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: production
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/staging_ci.yml
+++ b/.github/workflows/staging_ci.yml
@@ -1,7 +1,7 @@
 name: Staging CI
 
 on:
-  push:
+  pull_request:
     branches:
       - staging
 
@@ -67,27 +67,3 @@ jobs:
       - name: Run client tests
         run: bun test
         working-directory: ./client
-
-  # Only run if run-tests succeeds
-  merge-to-production:
-    needs: run-tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    # only run this job if it's triggered by a push to staging
-    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
-    steps:
-      - name: Checkout production
-        uses: actions/checkout@v4
-        with:
-          ref: production
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge staging into production
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git fetch origin production
-          git fetch origin staging
-          git merge origin/staging -m "Merge staging into production after successful CI"
-          git push


### PR DESCRIPTION
This changes the CI/CD pipeline to work as follows: 

1. A PR is opened targeting the staging branch.
2. A reviewer approves the PR and merges the branch.
3. A repo administrator can then merge the staging branch into the production branch, triggering the deployment runner.