### PR TITLE
Styling hotfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,11 @@ If you see your work on this web application and believe you haven't been proper
 
 If you would like to become a contributor on this project, please read [this guide](CONTRIBUTING.md).
 
-<a href="https://github.com/rsmith531/my_earth/graphs/contributors">
+<a href="https://github.com/rsmith531/my_earth/graphs/contributors" >
   <img src="https://contrib.rocks/image?repo=rsmith531/my_earth" alt="Github profile images of project contributors." width="100%" height="70px" />
 </a>
 
-Made with [contrib.rocks](https://contrib.rocks).
-
-<hr />
+<hr style="margin-top: 16px" />
 
 Want to know more about the technical implementation? See [here](technical_implementation.md).
 

--- a/client/components/page/Article.tsx
+++ b/client/components/page/Article.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from 'react';
  */
 function Article({ children }: { children: ReactNode }) {
   return (
-    <div className="relative py-12 min-h-dvh flex items-center">
+    <div className="relative py-4 pb-28 sm:py-12 px-4 sm:px-12 min-h-dvh h-dvh flex items-center sm:mt-0">
       <div className="z-0 inset-0 fixed pointer-events-none h-dvh">
         <Globe
           interactive={false}
@@ -28,7 +28,7 @@ function Article({ children }: { children: ReactNode }) {
           borderRadius: '15px',
           padding: '16px',
         }}
-        className=" relative m-auto bg-slate-900/95 max-w-4xl border-slate-200 border-2 z-10"
+        className="relative m-auto bg-slate-900/95 max-w-full sm:max-w-4xl border-slate-200 border-2 z-10 max-h-full p-4 overflow-scroll"
       >
         {children}
       </div>

--- a/client/components/page/Home.tsx
+++ b/client/components/page/Home.tsx
@@ -270,7 +270,7 @@ function Home({
       >
         <h1
           data-testid="home-title"
-          className="absolute"
+          className="absolute text-4xl"
           style={{ top: titlePosition, textAlign: 'center' }}
         >
           What is your favorite thing about Earth?

--- a/client/components/section/Globe.tsx
+++ b/client/components/section/Globe.tsx
@@ -257,7 +257,6 @@ function Globe({
     return () => clearInterval(intervalId);
   }, [globeMaterial]);
 
-  console.log(markerCoordinates);
   return (
     <div
       data-testid={'globe-root-element'}

--- a/client/components/ui/codeblock.tsx
+++ b/client/components/ui/codeblock.tsx
@@ -28,7 +28,7 @@ function CodeBlock({
 
   return (
     <div
-      className="relative"
+      className="relative max-w-full"
       style={{ display: inline ? 'inline-flex' : undefined }}
     >
       <SyntaxHighlighter

--- a/client/components/ui/image.tsx
+++ b/client/components/ui/image.tsx
@@ -48,15 +48,17 @@ function Image(
       {imageErrored ? (
         <div
           className={
-            'absolute overflow-clip bg-slate-400 flex flex-col gap-6 items-center justify-center'
+            'absolute overflow-clip bg-slate-400 flex flex-col gap-2 items-center justify-center p-2 sm:p-4'
           }
           style={{ width: resolvedWidth, height: resolvedHeight }}
         >
-          <BrokenImage
-            width={'20%'}
-            className="stroke-slate-200 fill-slate-200"
-          />
-          <p className="text-3xl">{props.alt ?? 'Could not load image'}</p>
+          {Number.parseInt(resolvedHeight) > 100 && (
+            <BrokenImage
+              width={'20%'}
+              className="stroke-slate-200 fill-slate-200"
+            />
+          )}
+          <h4 className="text-center">{props.alt ?? 'Could not load image'}</h4>
         </div>
       ) : null}
       <img

--- a/client/components/ui/slider.tsx
+++ b/client/components/ui/slider.tsx
@@ -62,7 +62,7 @@ function Slider({
         ref={sliderRef}
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="border-slate-200 bg-background ring-ring/50 block size-4 shrink-0 rounded-full border-[2px] shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root></div>

--- a/client/components/ui/sonner.tsx
+++ b/client/components/ui/sonner.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = "dark" } = useTheme()
 
   return (
     <Sonner

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -29,7 +29,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
         <div className="fixed bottom-14 right-[50%] translate-x-1/2 sm:translate-x-0 sm:top-4 sm:right-4 z-20">
           <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="bg-transparent">
+              <Button className="border-2 border-slate-200 aspect-square w-9">
                 <Hamburger className="fill-slate-200 stroke-slate-200" />
               </Button>
             </DropdownMenuTrigger>

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -26,14 +26,14 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
         <Outlet />
         <ReactQueryDevtools buttonPosition="bottom-left" />
         <TanStackRouterDevtools position="bottom-right" />
-        <div className="fixed top-4 right-4 z-20">
+        <div className="fixed bottom-14 right-[50%] translate-x-1/2 sm:translate-x-0 sm:top-4 sm:right-4 z-20">
           <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" className="bg-transparent">
                 <Hamburger className="fill-slate-200 stroke-slate-200" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-56 bg-slate-900" align="end">
+            <DropdownMenuContent className="w-56 bg-slate-900" align="center">
               <DropdownMenuGroup>
                 <Link to="/">
                   <DropdownMenuItem className="cursor-pointer">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -7,17 +7,7 @@
 
 /* TODO: move the rest of the custom styles into the Base layer like the <p>
 element */
-/* font sizes */
-h1{ font-size: var(--text-5xl); line-height: 2; }
-h2{ font-size: var(--text-4xl); line-height: 2; }
-h3{ font-size: var(--text-2xl); line-height: 2; }
-h4{ font-size: var(--text-xl); line-height: 2;}
 
-/* list styling */
-ol{ list-style: decimal; padding-left: 1rem; }
-ul{ list-style: disclosure-closed; padding-left: 1rem; }
-li{ padding-bottom: 0.5rem; }
-hr{ padding-bottom: 0.5rem; }
 input[type="checkbox"] { margin-left: -1rem !important; } /* override showdown's margin */
 
 /* anchor tag colors */
@@ -158,11 +148,19 @@ code {
     @apply border-border outline-ring/50;
     @apply text-slate-200
   }
-  p{ @apply text-base pb-4;}
+  p{ @apply text-base pb-4}
+  /* font sizes */
+  h1{ @apply text-3xl sm:text-5xl pb-3 }
+  h2{ @apply text-2xl sm:text-4xl pb-3 }
+  h3{ @apply text-xl sm:text-2xl pb-3 }
+  h4{ @apply text-lg sm:text-xl pb-3 }
+  /* list styling */
+  ol{ @apply list-decimal pl-4 }
+  ul{ @apply list-disc pl-4 }
+  li{ @apply pb-2 }
+  hr{ @apply pb-2 }
+
   body {
     @apply bg-background text-foreground;
-  }
-  h1 {
-    font-size: var(--text-4xl);
   }
 }

--- a/technical_implementation.md
+++ b/technical_implementation.md
@@ -126,3 +126,5 @@ The difference was that the first case required some requests in the stream to g
 The centerpiece of the UI is the big globe in a skybox (spacebox?). I couldn't have accomplished it without [react-globe.gl](https://vasturiano.github.io/react-globe.gl/). My goal was to let users see the notes that they write show up on the planet and see notes that others have written in the same place that they are now. I was hoping for a little bit of the wow factor of seeing our planet against the backdrop of space to leave the user awestruck and inspired.
 
 ## Closing Thoughts
+
+It was hard, but I'm glad I did it.


### PR DESCRIPTION
### What does this PR change?

1. Moves the nav menu button to the bottom of the screen on mobile.
2. Forces the sonner toast to use dark mode colors.
3. Make fonts smaller on mobile.
4. Don't show the broken image icon if the image is less than 100px tall.
5. Various styling fixes.

### What does this PR remove?

1. A stray console log running around in the `<Globe />` component.

### I have...

- [ ] Updated the documentation
- [ ] Added tests or examples
- [ ] Removed unused imports and variables
- [x] Deactivated `console.log()` statements used for debugging
- [ ] Removed extraneous comments
- [ ] Documented any new environment variables