### PR TITLE
Styling hotfixes

### DIFF
--- a/client/components/section/Globe.tsx
+++ b/client/components/section/Globe.tsx
@@ -267,6 +267,7 @@ function Globe({
         // disable autorotate when the user clicks the globe
         onGlobeClick={() => setAutoSpin(false)}
         globeMaterial={globeMaterial}
+        showGlobe={!!globeMaterial}
         width={canvasWidth}
         height={canvasHeight}
         waitForGlobeReady={false}

--- a/client/components/section/MarkdownRenderer.tsx
+++ b/client/components/section/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from 'rehype-raw';
 import { Image } from '@components/ui/image';
 import { CodeBlock } from '@components/ui/codeblock';
 import { atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Link } from '@tanstack/react-router';
 
 // TODO: make sure URLs go to the hostname of the website
 
@@ -23,6 +24,20 @@ export function MarkdownRenderer({ content }: { content: string }) {
         img(props) {
           const { node, ...rest } = props;
           return <Image width={rest.width} height={rest.height} {...rest} />;
+        },
+        a({ node, ...rest }) {
+          if (rest.href?.endsWith('.md')) {
+            return (
+              <Link
+                // @ts-expect-error string magic that will come out with a route
+                // that exists on this website in the end
+                to={`/${rest.href.split('/').pop()?.replace('.md', '') || '/'}`}
+              >
+                {rest.children}
+              </Link>
+            );
+          }
+          return <a {...rest} />;
         },
         code(props) {
           const { node, ...rest } = props;


### PR DESCRIPTION
### What does this PR change?

1. Does not render the globe until it's material has loaded.
2. Internal links in markdown are rendered in a Tanstack `<Link />` component.

## Administrative information

### Issues closed by this PR

- Closes #28.

### I have...

- [ ] Updated the documentation
- [ ] Added tests or examples
- [ ] Removed unused imports and variables
- [ ] Deactivated `console.log()` statements used for debugging
- [ ] Removed extraneous comments
- [ ] Documented any new environment variables