### PR TITLE
Nginx SPA hotfix

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -36,6 +36,9 @@ FROM nginx:alpine AS runner
 # copy the built client application from the builder stage to the nginx server
 COPY --from=builder /deployment/client/dist /usr/share/nginx/html
 
+# copy the nginx config file for serving a SPA to the nginx server
+COPY client/nginx.conf /usr/local/nginx/conf/nginx.conf
+
 # expose the port Nginx listens on (default HTTP port).
 EXPOSE 80
 

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,28 @@
+# client\nginx.conf
+
+server {
+  listen 80;
+
+  location / {
+    root /usr/share/nginx/html;
+
+    # This is due to nginx and the try_files behavior below, it will always
+    # try to hit the index as part of try_files.  If I set index as something
+    # that doesn't resolve, we don't have to worry about index.html being cached.
+    #
+    # If frequent updates occur, it's important that index.html not be cached
+    # in the browser.  Otherwise the software update will only occur when the
+    # cached page expires.  The If-Modified-Since is a better way to handle this
+    # for SPAs with frequent updates.
+    index unresolvable-file-html.html;
+
+    try_files $uri $uri/ @index;
+  }
+  # This seperate location is so the no cache policy only applies to the index and nothing else.
+  location @index {
+    root /usr/share/nginx/html;
+    add_header Cache-Control no-cache;
+    expires 0;
+    try_files /index.html =404;
+  }
+}


### PR DESCRIPTION
### What does this PR add?

1. Create nginx config to handle SPA style websites

### Other relevant information

Is there anything else that should be known? Share any screenshots or other information that might help a reviewer understand the PR.

- Supposedly since SPAs do all routing client-side, the only thing the server knows about is the index route, so if you do a page refresh (navigate outside the SPA context) from a non-root route, nginx won't know of its existence and 404. To fix this, you have to tell it all unknown routes should go back to the root route.

https://www.honlsoft.com/blog/2019-05-14-nginx-spa/
https://stackoverflow.com/questions/57917893/how-to-configure-nginx-properly-to-show-spa-application
https://stackoverflow.com/questions/44098136/nginx-config-with-spa-and-subdirectory-root

## Administrative information

### I have...

- [ ] Updated the documentation
- [ ] Added tests or examples
- [ ] Removed unused imports and variables
- [ ] Deactivated `console.log()` statements used for debugging
- [ ] Removed extraneous comments
- [ ] Documented any new environment variables