### PR TITLE
Styling hotfixes

### DIFF
--- a/client/components/section/Globe.tsx
+++ b/client/components/section/Globe.tsx
@@ -268,6 +268,7 @@ function Globe({
         onGlobeClick={() => setAutoSpin(false)}
         globeMaterial={globeMaterial}
         showGlobe={!!globeMaterial}
+        showAtmosphere={!!globeMaterial}
         width={canvasWidth}
         height={canvasHeight}
         waitForGlobeReady={false}

--- a/client/components/section/Globe.tsx
+++ b/client/components/section/Globe.tsx
@@ -92,13 +92,25 @@ function Globe({
   }));
 
   /**
-   * resize the canvas to the size of the viewport
+   * Resize the canvas to the size of the viewport using ResizeObserver
    */
   useEffect(() => {
     if (!globeRoot.current) return;
-    const { offsetWidth, offsetHeight } = globeRoot.current;
-    setCanvasWidth(offsetWidth);
-    setCanvasHeight(offsetHeight);
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === globeRoot.current) {
+          setCanvasWidth(entry.contentRect.width);
+          setCanvasHeight(entry.contentRect.height);
+        }
+      }
+    });
+
+    resizeObserver.observe(globeRoot.current);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
   }, []);
 
   /**
@@ -118,6 +130,7 @@ function Globe({
   }, [interactive]);
 
   const animationFrameId = useRef<number | null>(null);
+
   /**
    * gradually brings verticalOffset to 0 or 500 using a linear or cubic
    * ease-in-out animation.
@@ -256,6 +269,10 @@ function Globe({
 
     return () => clearInterval(intervalId);
   }, [globeMaterial]);
+
+  // const renderCount = useRef<number>(0);
+  // console.log(`Globe render count: ${renderCount.current}`);
+  // renderCount.current += 1;
 
   return (
     <div


### PR DESCRIPTION
### What does this PR add?

1. Hides the atmosphere from rendering while the globe isn't being rendered. This avoids the weird halo on the canvas created by an atmosphere with no globe inside it.

### What does this PR change?

1.The previous method for detecting changes in the size of the globe's container did not work, but this one uses the [resize observer api](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) and does work

## Administrative information

### Issues closed by this PR

- Closes #21.

### I have...

- [ ] Updated the documentation
- [ ] Added tests or examples
- [ ] Removed unused imports and variables
- [x] Deactivated `console.log()` statements used for debugging
- [ ] Removed extraneous comments
- [ ] Documented any new environment variables